### PR TITLE
Use ncat instead of nmap for port check

### DIFF
--- a/tunnelChecker/tunchecker.sh
+++ b/tunnelChecker/tunchecker.sh
@@ -14,7 +14,18 @@ fi
 
 VPN_ADDR=`ip -4 addr show tun0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'`
 VPN_RESP=`curl -sS --interface tun0 $IP_CHECK`
-VPN_PORT=`if [ "$PORT_FORWARD" != "" ]; then if nmap -p $PORT_FORWARD $VPN_ADDR | grep -q "open"; then echo "open"; else echo "closed"; fi; else echo "not set"; fi`
+
+if [ "$PORT_FORWARD" != "" ]; then
+  nc -z $VPN_ADDR $PORT_FORWARD
+  RESULT=$?
+  if [ $RESULT - eq 0 ]; then 
+    VPN_PORT="open"; 
+  else 
+    VPN_PORT="closed"; 
+  fi; 
+else 
+  VPN_PORT="not set"; 
+fi
 
 echo "Interface IP is "$VPN_ADDR
 echo "API Query IP is "$VPN_RESP


### PR DESCRIPTION
As discussed in #2 This change simply swaps out nmap for ncat (nc) which is a utility provided by the nmap project but is much more lightweight than nmap.

https://nmap.org/ncat/


I haven't tested this myself so it will need some validation.